### PR TITLE
Update requirements.txt to fix breaking changes in huggingface_hub 0.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ textract==1.6.5
 pandas==2.1.3
 qdrant-client==1.12.0
 matplotlib==3.9.2
+huggingface_hub==0.25.2


### PR DESCRIPTION
cached_download has been removed.
We need to stay at 0.25.2 so specified version of langchain will work.